### PR TITLE
Update formula to support NGINX mainline repository

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 zendserver formula
 ================
 
+0.1.6 (05-02-2016)
+- Added NGINX Mainline support to the repo
 
 0.1.5 (19-03-2015)
 - Added extension management

--- a/pillar.example
+++ b/pillar.example
@@ -16,6 +16,9 @@ zendserver:
   # separate users
   enable_itk: False
 
+  # Whether to use the nginx mainline repo or default stable
+  nginx_mainline: False
+
   # Whether to bootstrap the Zend Server, otherwise you'll be
   # asked to do so when you login to the ZendServer admin page.
   bootstrap: False

--- a/zendserver/repo/nginx.sls
+++ b/zendserver/repo/nginx.sls
@@ -1,28 +1,22 @@
+# Install Nginx repository
+{%- set repo_url = 'http://nginx.org/packages' %}
+
 {%- set lsb_codename = salt['grains.get']('oscodename') %}
 {%- set lsb_distrib_id = salt['grains.get']('lsb_distrib_id') %}
-# Install Nginx repository
+
+# Handle mainline switch
+{%- if salt['pillar.get']('zendserver:nginx_mainline', False) %}
+{%- set repo_url = repo_url ~ '/mainline' %}
+{%- endif %}
 
 nginx_repo:
   pkgrepo.managed:
     - humanname: Nginx PPA
-{%- if lsb_distrib_id == 'Debian' %}
-    - dist: {{ lsb_codename }}
-    - name: deb http://nginx.org/packages/debian/ {{ lsb_codename }} nginx
-{%- elif lsb_distrib_id == 'Ubuntu' %}
-{%- if lsb_codename == 'vivid' %}
-    - name: deb http://nginx.org/packages/ubuntu/ utopic nginx
-    - dist: utopic
-{%- else %}
-    - name: deb http://nginx.org/packages/ubuntu/ {{ lsb_codename }} nginx
-    - dist: {{ lsb_codename }}
-{%- endif %}
-{%- else %}
-    - dist: {{ lsb_codename }}
-    - name: deb http://nginx.org/packages/{{ lsb_distrib_id }}/ {{ lsb_codename }} nginx
-{%- endif %}
+    - name: deb {{ repo_url }}/{{ lsb_distrib_id }}/ {{ lsb_codename }} nginx
     - file: /etc/apt/sources.list.d/nginx.list
     - keyid: 7BD9BF62
     - key_url: http://nginx.org/keys/nginx_signing.key
     - keyserver: keyserver.ubuntu.com
     - require_in:
       - pkg: nginx
+    - clean_file: True


### PR DESCRIPTION
This PR adds support for NGINX Mainline so HTTP2 can be used as well :)
