### PR TITLE
Fix for Salt 2016.3: Either use key_url or keyserver not both.

### DIFF
--- a/zendserver/repo/nginx.sls
+++ b/zendserver/repo/nginx.sls
@@ -14,9 +14,7 @@ nginx_repo:
     - humanname: Nginx PPA
     - name: deb {{ repo_url }}/{{ lsb_distrib_id }}/ {{ lsb_codename }} nginx
     - file: /etc/apt/sources.list.d/nginx.list
-    - keyid: 7BD9BF62
     - key_url: http://nginx.org/keys/nginx_signing.key
-    - keyserver: keyserver.ubuntu.com
     - require_in:
       - pkg: nginx
     - clean_file: True

--- a/zendserver/repo/zendserver.sls
+++ b/zendserver/repo/zendserver.sls
@@ -13,9 +13,7 @@ zendserver_repo:
     - name: deb http://repos.zend.com/zend-server/{{zend_version}}/deb_ssl1.0 server non-free
     {% endif %}
     - file: /etc/apt/sources.list.d/zendserver.list
-    - keyid: F7D2C623
     - key_url: http://repos.zend.com/zend.key
-    - keyserver: keyserver.ubuntu.com
     - refresh: True
     - require_in:
       - pkg: zendserver


### PR DESCRIPTION
This resolves the following issue introduced in Salt 2016.3.0:

```
          ID: nginx_repo
    Function: pkgrepo.managed
        Name: deb http://nginx.org/packages/ubuntu/ trusty nginx
      Result: False
     Comment: You may not use both "keyid"/"keyserver" and "key_url" argument.
     Started: 08:01:59.092297
    Duration: 1.746 ms
     Changes:   
```

```
          ID: zendserver_repo
    Function: pkgrepo.managed
        Name: deb http://repos.zend.com/zend-server/7.0/deb_ssl1.0 server non-free
      Result: False
     Comment: You may not use both "keyid"/"keyserver" and "key_url" argument.
     Started: 08:02:03.191386
    Duration: 1.742 ms
     Changes: 
```

This change is backwards compatible with versions prior to 2016.3.0.
